### PR TITLE
enables IO error propagation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,10 +165,14 @@ pub fn glob_with(pattern: &str, options: &MatchOptions) -> Result<Paths, Pattern
 
     let scope = root.map(to_scope).unwrap_or_else(|| Path::new("."));
 
-    let dir_patterns = pattern.slice_from(cmp::min(root_len, pattern.len()))
-                       .split_terminator(is_sep)
-                       .map(|s| Pattern::new(s).unwrap())
-                       .collect::<Vec<Pattern>>();
+    let mut dir_patterns = Vec::new();
+    let mut components = pattern.slice_from(cmp::min(root_len, pattern.len()))
+                         .split_terminator(is_sep);
+
+    for component in components {
+        let compiled = try!(Pattern::new(component));
+        dir_patterns.push(compiled);
+    }
 
     let require_dir = pattern.chars().next_back().map(is_sep) == Some(true);
     let todo = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -899,13 +899,24 @@ mod test {
         assert!(glob("abc[def").err().unwrap().pos == 3);
     }
 
+    // this test assumes that there is a /root directory and that
+    // the user running this test is not root or otherwise doesn't
+    // have permission to read its contents
     #[cfg(unix)]
     #[test]
     fn test_iteration_errors() {
         let mut iter = glob("/root/*").unwrap();
+
+        // GlobErrors shouldn't halt iteration
         let next = iter.next();
         assert!(next.is_some());
-        assert!(next.unwrap().is_err());
+
+        let err = next.unwrap();
+        assert!(err.is_err());
+
+        let err = err.unwrap_err();
+        assert!(*err.path() == Path::new("/root"));
+        assert!(err.error().kind == ::std::io::IoErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,15 +208,6 @@ impl fmt::Show for GlobError {
 /// such as failing to read a particular directory's contents.
 pub type GlobResult = Result<Path, GlobError>;
 
-macro_rules! try_todo {
-    ($expr:expr) => (match $expr {
-        Ok(val) => Some(val),
-        Err(err) => {
-            return Some(Err(FromError::from_error(err)))
-        }
-    })
-}
-
 impl Iterator for Paths {
     type Item = GlobResult;
 

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -77,6 +77,8 @@ fn main() {
     mk_file("r/one/a.md", false);
     mk_file("r/one/another", true);
     mk_file("r/one/another/a.md", false);
+    mk_file("r/one/another/deep", true);
+    mk_file("r/one/another/deep/spelunking.md", false);
     mk_file("r/another", true);
     mk_file("r/another/a.md", false);
     mk_file("r/two", true);
@@ -87,19 +89,22 @@ fn main() {
     // all recursive entities
     assert_eq!(glob_vec("r/**"), vec!(
         Path::new("r/another"),
-        Path::new("r/another/a.md"),
-        Path::new("r/current_dir.md"),
         Path::new("r/one"),
-        Path::new("r/one/a.md"),
         Path::new("r/one/another"),
-        Path::new("r/one/another/a.md"),
+        Path::new("r/one/another/deep"),
         Path::new("r/three"),
-        Path::new("r/three/c.md"),
-        Path::new("r/two"),
-        Path::new("r/two/b.md")));
+        Path::new("r/two")));
 
     // collapse consecutive recursive patterns
     assert_eq!(glob_vec("r/**/**"), vec!(
+        Path::new("r/another"),
+        Path::new("r/one"),
+        Path::new("r/one/another"),
+        Path::new("r/one/another/deep"),
+        Path::new("r/three"),
+        Path::new("r/two")));
+
+    assert_eq!(glob_vec("r/**/*"), vec!(
         Path::new("r/another"),
         Path::new("r/another/a.md"),
         Path::new("r/current_dir.md"),
@@ -107,6 +112,8 @@ fn main() {
         Path::new("r/one/a.md"),
         Path::new("r/one/another"),
         Path::new("r/one/another/a.md"),
+        Path::new("r/one/another/deep"),
+        Path::new("r/one/another/deep/spelunking.md"),
         Path::new("r/three"),
         Path::new("r/three/c.md"),
         Path::new("r/two"),
@@ -118,6 +125,7 @@ fn main() {
         Path::new("r/current_dir.md"),
         Path::new("r/one/a.md"),
         Path::new("r/one/another/a.md"),
+        Path::new("r/one/another/deep/spelunking.md"),
         Path::new("r/three/c.md"),
         Path::new("r/two/b.md")));
 

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -40,7 +40,7 @@ fn main() {
     }
 
     fn glob_vec(pattern: &str) -> Vec<Path> {
-        glob(pattern).collect()
+        glob(pattern).unwrap().collect()
     }
 
     let root = TempDir::new("glob-tests");

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -40,7 +40,7 @@ fn main() {
     }
 
     fn glob_vec(pattern: &str) -> Vec<Path> {
-        glob(pattern).unwrap().collect()
+        glob(pattern).unwrap().filter_map(|r| r.ok()).collect()
     }
 
     let root = TempDir::new("glob-tests");


### PR DESCRIPTION
Sorry for the mess with these PRs. I decided to base this off of the latest work (#27) I did because the code changed drastically since then and #26.

---

This allows previously-repressed IO errors to propagate during
iteration. In particular, the Iterator `Item` is now a `Result` type
which represents either a matched `Path` or a `GlobError`, which is
simply a combination of an `IoError` and the related `Path` (for
context). Currently, the only potential for errors is during the
call to `readdir` and the errors are likely to be due to the lack of
permissions. An emitted error in this case essentially means that the
given path matched or partially matched, but its contents could not be
read to determine if they match.

It's important to note that this is an error for a given iteration, that
is, it doesn't completely halt the iteration process. That is, errors
are still returned as `Some()`. This enables the user to simply skip
the unreadable paths by using something like filter_map(Result::ok),
essentially replicating the previous behavior.