### PR TITLE
Update to latest Rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
        html_root_url = "http://doc.rust-lang.org/glob/")]
 #![cfg_attr(test, deny(warnings))]
-#![cfg_attr(test, feature(os))]
-#![feature(path, io, core, collections, hash, std_misc, unicode)]
+#![feature(path, io, core, collections, hash, std_misc, unicode, env)]
 
 use std::ascii::AsciiExt;
 use std::cell::Cell;
-use std::{cmp, path};
+use std::cmp;
 use std::old_io::fs::{self, PathExtensions};
-use std::path::is_sep;
+use std::old_path as path;
+use std::old_path::is_sep;
 use std::string::String;
 use std::fmt;
 use std::old_io::IoError;
@@ -137,10 +137,10 @@ pub fn glob_with(pattern: &str, options: &MatchOptions) -> Result<Paths, Pattern
 
     #[cfg(windows)]
     fn to_scope(p: Path) -> Path {
-        use std::os::getcwd;
+        use std::env::current_dir;
 
         if path::windows::is_vol_relative(&p) {
-            let mut cwd = getcwd().unwrap();
+            let mut cwd = current_dir().unwrap();
             cwd.push(p);
             cwd
         } else {
@@ -861,7 +861,7 @@ impl MatchOptions {
 
 #[cfg(test)]
 mod test {
-    use std::os;
+    use std::env;
     use super::{glob, Pattern, MatchOptions};
 
     #[test]
@@ -918,7 +918,7 @@ mod test {
         assert!(glob("//").unwrap().next().is_some());
 
         // check windows absolute paths with host/device components
-        let root_with_device = os::getcwd().unwrap().root_path().unwrap().join("*");
+        let root_with_device = env::current_dir().unwrap().root_path().unwrap().join("*");
         // FIXME (#9639): This needs to handle non-utf8 paths
         assert!(glob(root_with_device.as_str().unwrap()).unwrap().next().is_some());
     }

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -9,14 +9,12 @@
 // except according to those terms.
 
 // ignore-windows TempDir may cause IoError on windows: #10462
-#![feature(path, os, io)]
-
-#![feature(path, os, io)]
+#![feature(path, env, io)]
 
 extern crate glob;
 
 use glob::glob;
-use std::os;
+use std::env;
 use std::old_io;
 use std::old_io::TempDir;
 
@@ -42,7 +40,7 @@ fn main() {
 
     let root = TempDir::new("glob-tests");
     let root = root.ok().expect("Should have created a temp directory");
-    assert!(os::change_dir(root.path()).is_ok());
+    assert!(env::set_current_dir(root.path()).is_ok());
 
     mk_file("aaa", true);
     mk_file("aaa/apple", true);
@@ -55,7 +53,7 @@ fn main() {
     mk_file("bbb/specials/!", false);
 
     // windows does not allow `*` or `?` characters to exist in filenames
-    if os::consts::FAMILY != "windows" {
+    if env::consts::FAMILY != "windows" {
         mk_file("bbb/specials/*", false);
         mk_file("bbb/specials/?", false);
     }
@@ -156,7 +154,7 @@ fn main() {
     assert_eq!(glob_vec("aaa/apple/nope"), Vec::new());
 
     // windows should support both / and \ as directory separators
-    if os::consts::FAMILY == "windows" {
+    if env::consts::FAMILY == "windows" {
         assert_eq!(glob_vec("aaa\\apple"), vec!(Path::new("aaa/apple")));
     }
 
@@ -228,12 +226,12 @@ fn main() {
     assert_eq!(glob_vec("bbb/specials/!"), vec!(Path::new("bbb/specials/!")));
     assert_eq!(glob_vec("bbb/specials/[]]"), vec!(Path::new("bbb/specials/]")));
 
-    if os::consts::FAMILY != "windows" {
+    if env::consts::FAMILY != "windows" {
         assert_eq!(glob_vec("bbb/specials/[*]"), vec!(Path::new("bbb/specials/*")));
         assert_eq!(glob_vec("bbb/specials/[?]"), vec!(Path::new("bbb/specials/?")));
     }
 
-    if os::consts::FAMILY == "windows" {
+    if env::consts::FAMILY == "windows" {
 
         assert_eq!(glob_vec("bbb/specials/[![]"), vec!(
             Path::new("bbb/specials/!"),


### PR DESCRIPTION
glob wasn't compiling with latest nightlies (at least on windows).

path -> old_path
os::getcwd -> env::current_dir
os::consts -> env::consts
os::change_dir -> env::set_current_dir

And changed features accordingly.