### PR TITLE
Remove description function in GlobError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,10 +292,6 @@ impl GlobError {
 }
 
 impl Error for GlobError {
-    fn description(&self) -> &str {
-        self.error.description()
-    }
-
     #[allow(unknown_lints, bare_trait_objects)]
     fn cause(&self) -> Option<&Error> {
         Some(&self.error)


### PR DESCRIPTION
The description call is deprecated and fmt::Display is already implemented.