### PR TITLE
Allow deprecation to `Error::description`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,7 @@ impl GlobError {
 }
 
 impl Error for GlobError {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         self.error.description()
     }


### PR DESCRIPTION
We cannot simply remove it as it's a breaking change, suggested on https://github.com/rust-lang/glob/pull/94#discussion_r371199371.
Closes #94

Signed-off-by: Yuki Okushi <jtitor@2k36.org>