### PR TITLE
Switch off of unmaintained `tempdir` crate to `tempfile`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ Support for matching file paths against Unix shell style patterns.
 categories = ["filesystem"]
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3.3.0"
 doc-comment = "0.3"

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -13,13 +13,12 @@
 #![cfg_attr(test, deny(warnings))]
 
 extern crate glob;
-extern crate tempdir;
+extern crate tempfile;
 
 use glob::glob;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use tempdir::TempDir;
 
 #[test]
 fn main() {
@@ -35,7 +34,7 @@ fn main() {
         glob(pattern).unwrap().map(|r| r.unwrap()).collect()
     }
 
-    let root = TempDir::new("glob-tests");
+    let root = tempfile::Builder::new().prefix("glob-tests").tempdir();
     let root = root.ok().expect("Should have created a temp directory");
     assert!(env::set_current_dir(root.path()).is_ok());
 


### PR DESCRIPTION
See https://github.com/rust-lang-deprecated/tempdir#deprecation-note.