### PR TITLE
Add FIXME for tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ Support for matching file paths against Unix shell style patterns.
 categories = ["filesystem"]
 
 [dev-dependencies]
+# FIXME: Replace it with `tempfile` once we bump up MSRV.
 tempdir = "0.3"
 doc-comment = "0.3"


### PR DESCRIPTION
We've received some PRs to replace the `tempdir` crate with `tempfile` as the former is unmaintained.
However, we cannot simply replace it due to our MSRV. Precisely speaking, it doesn't break but it needs some CI tweaks and we concluded that it wasn't worth doing so. This FIXME clarifies it.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>