### PR TITLE
Respect `require_literal_leading_dot` option in `glob_with` method for path components

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,6 +878,9 @@ fn fill_todo(
             });
             match dirs {
                 Ok(mut children) => {
+                    if options.require_literal_leading_dot {
+                        children.retain(|x| !x.file_name().unwrap().to_str().unwrap().starts_with("."));
+                    }
                     children.sort_by(|p1, p2| p2.file_name().cmp(&p1.file_name()));
                     todo.extend(children.into_iter().map(|x| Ok((x, idx))));
 

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -309,8 +309,8 @@ fn main() {
     assert_eq!(glob_with_vec("i/**/*c*", &options), Vec::<PathBuf>::new());
     assert_eq!(glob_with_vec("i/**/*d*", &options), Vec::<PathBuf>::new());
     assert_eq!(glob_with_vec("i/**/*e*", &options), vec!(
-        PathBuf::from("i/qwe/eee")
-    ));
+        PathBuf::from("i/qwe"),
+        PathBuf::from("i/qwe/eee")));
 
     if env::consts::FAMILY != "windows" {
         assert_eq!(

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -35,7 +35,7 @@ fn main() {
         glob(pattern).unwrap().map(|r| r.unwrap()).collect()
     }
 
-    fn glob_with_vec(pattern: &str, options: &glob::MatchOptions) -> Vec<PathBuf> {
+    fn glob_with_vec(pattern: &str, options: glob::MatchOptions) -> Vec<PathBuf> {
         glob_with(pattern, options).unwrap().map(|r| r.unwrap()).collect()
     }
 
@@ -305,12 +305,13 @@ fn main() {
         require_literal_separator: true,
         require_literal_leading_dot: true,
     };
-    assert_eq!(glob_with_vec("i/**/*a*", &options), Vec::<PathBuf>::new());
-    assert_eq!(glob_with_vec("i/**/*c*", &options), Vec::<PathBuf>::new());
-    assert_eq!(glob_with_vec("i/**/*d*", &options), Vec::<PathBuf>::new());
-    assert_eq!(glob_with_vec("i/**/*e*", &options), vec!(
-        PathBuf::from("i/qwe"),
-        PathBuf::from("i/qwe/eee")));
+    assert_eq!(glob_with_vec("i/**/*a*", options), Vec::<PathBuf>::new());
+    assert_eq!(glob_with_vec("i/**/*c*", options), Vec::<PathBuf>::new());
+    assert_eq!(glob_with_vec("i/**/*d*", options), Vec::<PathBuf>::new());
+    assert_eq!(
+        glob_with_vec("i/**/*e*", options),
+        vec!(PathBuf::from("i/qwe"), PathBuf::from("i/qwe/eee"))
+    );
 
     if env::consts::FAMILY != "windows" {
         assert_eq!(

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -15,7 +15,7 @@
 extern crate glob;
 extern crate tempdir;
 
-use glob::glob;
+use glob::{glob, glob_with};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -33,6 +33,10 @@ fn main() {
 
     fn glob_vec(pattern: &str) -> Vec<PathBuf> {
         glob(pattern).unwrap().map(|r| r.unwrap()).collect()
+    }
+
+    fn glob_with_vec(pattern: &str, options: &glob::MatchOptions) -> Vec<PathBuf> {
+        glob_with(pattern, options).unwrap().map(|r| r.unwrap()).collect()
     }
 
     let root = TempDir::new("glob-tests");
@@ -287,6 +291,26 @@ fn main() {
         glob_vec("bbb/specials/[]]"),
         vec!(PathBuf::from("bbb/specials/]"))
     );
+
+    mk_file("i", true);
+    mk_file("i/qwe", true);
+    mk_file("i/qwe/.aaa", false);
+    mk_file("i/qwe/.bbb", true);
+    mk_file("i/qwe/.bbb/ccc", false);
+    mk_file("i/qwe/.bbb/.ddd", false);
+    mk_file("i/qwe/eee", false);
+
+    let options = glob::MatchOptions {
+        case_sensitive: false,
+        require_literal_separator: true,
+        require_literal_leading_dot: true,
+    };
+    assert_eq!(glob_with_vec("i/**/*a*", &options), Vec::<PathBuf>::new());
+    assert_eq!(glob_with_vec("i/**/*c*", &options), Vec::<PathBuf>::new());
+    assert_eq!(glob_with_vec("i/**/*d*", &options), Vec::<PathBuf>::new());
+    assert_eq!(glob_with_vec("i/**/*e*", &options), vec!(
+        PathBuf::from("i/qwe/eee")
+    ));
 
     if env::consts::FAMILY != "windows" {
         assert_eq!(


### PR DESCRIPTION
This pulls the commits on #68 with a rebase into the latest master.
Closes #68 
Fixes #67