### PR TITLE
Remove "extern crate" directions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,6 @@ To use `glob`, add this to your `Cargo.toml`:
 glob = "0.3.1"
 ```
 
-And add this to your crate root:
-
-```rust
-extern crate glob;
-```
-
 ## Examples
 
 Print all jpg files in /media/ and all of its subdirectories.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ To use `glob`, add this to your `Cargo.toml`:
 glob = "0.3.1"
 ```
 
+If you're using Rust 1.30 or earlier, or edition 2015, add this to your crate root:
+```rust
+extern crate glob;
+```
+
 ## Examples
 
 Print all jpg files in /media/ and all of its subdirectories.


### PR DESCRIPTION
You no longer need to add `extern crate` directives for modern Rust editions.