### PR TITLE
Check only (no longer test) at the MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: CI
 
 on:
   pull_request:
@@ -7,29 +7,28 @@ on:
       - master
 
 jobs:
-  os_tests:
-    name: "Tests / OS: ${{ matrix.os }} - ${{ matrix.channel }}"
+  test:
+    name: Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         channel:
-        - stable
-        - beta
-        - nightly
-        - 1.23.0
+          - stable
+          - beta
+          - nightly
+          - 1.23.0
         os:
-        # FIXME: compiling with 1.23 on macOS 12 fails to linL
-        # archive member 'rust.metadata.bin' with length 40821 is not mach-o or llvm bitcode file
-        - macos-11
-        - windows-2022
-        - ubuntu-22.04
+          - macos-11
+          - windows-2022
+          - ubuntu-22.04
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
     - name: Update rust
-      run: rustup update ${{ matrix.channel }} --no-self-update
+      run: |
+        rustup default ${{ matrix.channel }}
+        rustup update --no-self-update
 
-    - name: Tests
-      run: cargo +${{ matrix.channel }} test --all
+    - run: cargo test --all

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,3 +49,17 @@ jobs:
         rustup update --no-self-update
 
     - run: cargo build
+
+  success:
+    needs:
+      - test
+      - msrv
+    runs-on: ubuntu-latest
+    # GitHub branch protection is exceedingly silly and treats "jobs skipped because a dependency
+    # failed" as success. So we have to do some contortions to ensure the job fails if any of its
+    # dependencies fails.
+    if: always() # make sure this is never "skipped"
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: check if any dependency failed
+        run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,13 +14,16 @@ jobs:
       matrix:
         channel:
           - stable
-          - beta
           - nightly
           - 1.63.0 # MSRV of test dependencies
         os:
-          - macos-11
-          - windows-2022
-          - ubuntu-22.04
+          - macos-13 # x86 MacOS
+          - macos-15 # Arm MacOS
+          - windows-2025
+          - ubuntu-24.04
+        include:
+          - channel: beta
+            os: ubuntu-24.04
 
     steps:
     - name: Checkout repository
@@ -35,7 +38,7 @@ jobs:
 
   msrv:
     name: Check building with the MSRV
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.23.0
+          - 1.63.0 # MSRV of test dependencies
         os:
           - macos-11
           - windows-2022
@@ -32,3 +32,17 @@ jobs:
         rustup update --no-self-update
 
     - run: cargo test --all
+
+  msrv:
+    name: Check building with the MSRV
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Update rust
+      run: |
+        rustup default 1.23.0
+        rustup update --no-self-update
+
+    - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,9 @@ description = """
 Support for matching file paths against Unix shell style patterns.
 """
 categories = ["filesystem"]
+rust-version = "1.23.0"
 
 [dev-dependencies]
-# FIXME: Replace it with `tempfile` once we bump up MSRV.
+# FIXME: This should be replaced by `tempfile`
 tempdir = "0.3"
 doc-comment = "0.3"


### PR DESCRIPTION
Adjust CI so we only run a check the main crate at the MSRV (1.23), running tests only at the MSRV of test dependencies. This allows us to keep CI passing without increasing `glob`'s MSRV to match that of `libc` (which since recently is 1.63.0) or other test dependencies.

Additionally, set `rust-version` in Cargo.toml.