### PR TITLE
Bump the MSRV to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,8 +54,6 @@ jobs:
         rustup default beta
         rustup component add clippy
         rustup update --no-self-update
-
-    # FIXME(msrv): suggestions do not work in 1.23, nor dows `#![allow(clippy::...)]`
     - run: cargo clippy --all -- -Aclippy::while_let_loop
 
   msrv:
@@ -67,7 +65,7 @@ jobs:
 
     - name: Update rust
       run: |
-        rustup default 1.23.0
+        rustup default 1.63.0
         rustup update --no-self-update
 
     - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Support for matching file paths against Unix shell style patterns.
 """
 categories = ["filesystem"]
-rust-version = "1.23.0"
+rust-version = "1.63.0"
 
 [dev-dependencies]
 # FIXME: This should be replaced by `tempfile`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
     html_root_url = "https://docs.rs/glob/0.3.1"
 )]
 #![deny(missing_docs)]
+#![allow(clippy::while_let_loop)]
 
 #[cfg(test)]
 #[macro_use]
@@ -390,7 +391,7 @@ impl Iterator for Paths {
         if let Some(scope) = self.scope.take() {
             if !self.dir_patterns.is_empty() {
                 // Shouldn't happen, but we're using -1 as a special index.
-                assert!(self.dir_patterns.len() < std::usize::MAX);
+                assert!(self.dir_patterns.len() < usize::MAX);
 
                 fill_todo(&mut self.todo, &self.dir_patterns, 0, &scope, self.options);
             }
@@ -408,7 +409,7 @@ impl Iterator for Paths {
 
             // idx -1: was already checked by fill_todo, maybe path was '.' or
             // '..' that we can't match here because of normalization.
-            if idx == std::usize::MAX {
+            if idx == usize::MAX {
                 if self.require_dir && !path.is_directory {
                     continue;
                 }
@@ -895,7 +896,7 @@ fn fill_todo(
             // We know it's good, so don't make the iterator match this path
             // against the pattern again. In particular, it can't match
             // . or .. globs since these never show up as path components.
-            todo.push(Ok((next_path, std::usize::MAX)));
+            todo.push(Ok((next_path, usize::MAX)));
         } else {
             fill_todo(todo, patterns, idx + 1, &next_path, options);
         }


### PR DESCRIPTION
Upgrade to a more modern version of Rust. 1.63 is the MSRV of various common ecosystem crates (libc and everything that derives from it), we have no need to support anything older here.