### PR TITLE
Implement `Serialize` and `Deserialize` from `serde` in `Pattern`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,13 @@ Support for matching file paths against Unix shell style patterns.
 categories = ["filesystem"]
 rust-version = "1.63.0"
 
+[dependencies]
+serde = { version = "1.0", optional = true, default-features = false, features = ["std"] }
+
 [dev-dependencies]
 # FIXME: This should be replaced by `tempfile`
 tempdir = "0.3"
 doc-comment = "0.3"
+
+[features]
+serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ for entry in glob("/media/**/*.jpg").expect("Failed to read glob pattern") {
     }
 }
 ```
+
+### `serde` Support
+
+The `Pattern` type implements `Serialize` and `Deserialize` from the `serde` crate when the `serde` feature is enabled. This allows `Pattern` instances to be easily serialized to and deserialized from various formats, such as JSON.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,10 @@
 //!     }
 //! }
 //! ```
+//!
+//! # `serde` Support
+//!
+//! The `Pattern` type implements `Serialize` and `Deserialize` from the `serde` crate when the `serde` feature is enabled. This allows `Pattern` instances to be easily serialized to and deserialized from various formats, such as JSON.
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
@@ -570,6 +574,27 @@ impl FromStr for Pattern {
 
     fn from_str(s: &str) -> Result<Self, PatternError> {
         Self::new(s)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for Pattern {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        serializer.serialize_str(&self.original)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Deserialize<'de> for Pattern {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::new(&s).map_err(serde::de::Error::custom)
     }
 }
 


### PR DESCRIPTION
I need to load glob patterns from a configuration file but got an error as there is no `Deserialize` implementation for `Pattern`.

This change adds a `serde` feature to the crate that enables an implementation of `serde::Serialize` and `serde::Deserialize` on the `Pattern` struct.

Closes #136.