### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         channel:
           - stable
           - nightly
-          - 1.63.0 # MSRV of test dependencies
+          - 1.71.0 # MSRV of test dependencies
         os:
           - macos-13 # x86 MacOS
           - macos-15 # Arm MacOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,5 @@ categories = ["filesystem"]
 rust-version = "1.63.0"
 
 [dev-dependencies]
-# FIXME: This should be replaced by `tempfile`
-tempdir = "0.3"
+tempfile = "3"
 doc-comment = "0.3"

--- a/tests/glob-std.rs
+++ b/tests/glob-std.rs
@@ -13,13 +13,12 @@
 #![cfg_attr(test, deny(warnings))]
 
 extern crate glob;
-extern crate tempdir;
+extern crate tempfile;
 
 use glob::{glob, glob_with};
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use tempdir::TempDir;
 
 #[test]
 fn main() {
@@ -68,8 +67,8 @@ fn main() {
             .collect()
     }
 
-    let root = TempDir::new("glob-tests");
-    let root = root.ok().expect("Should have created a temp directory");
+    let root = tempfile::tempdir();
+    let root = root.expect("Should have created a temp directory");
     assert!(env::set_current_dir(root.path()).is_ok());
 
     mk_file("aaa", true);


### PR DESCRIPTION
as the tempdir crate has been superseded by tempfile.

Now that MSRV was raised in https://github.com/rust-lang/glob/pull/172 we can replace tempdir with tempfile.