### PR TITLE
Pattern error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,27 +502,51 @@ impl Iterator for Paths {
 /// A pattern parsing error.
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
+#[non_exhaustive]
 pub struct PatternError {
     /// The approximate character index of where the error occurred.
     pub pos: usize,
 
-    /// A message describing the error.
-    pub msg: &'static str,
+    /// Specific kind of pattern error.
+    pub kind: PatternErrorKind,
 }
 
-impl Error for PatternError {
-    fn description(&self) -> &str {
-        self.msg
-    }
-}
+impl Error for PatternError {}
 
 impl fmt::Display for PatternError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "Pattern syntax error near position {}: {}",
-            self.pos, self.msg
+            self.pos, self.kind
         )
+    }
+}
+
+/// Define kinds of Error that can happen during parsing Pattern
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
+pub enum PatternErrorKind {
+    /// Wildcard should be only `*` or `**`
+    InvalidWildcards,
+    /// Recursive wildcard should be in `**/` | `a/**/b` | `a/**` structure
+    InvalidRecursiveWildcards,
+    /// Range pattern should be enclosed by `[]`
+    InvalidRange,
+}
+
+impl fmt::Display for PatternErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            PatternErrorKind::InvalidWildcards => {
+                "wildcards are either regular `*` or recursive `**`"
+            }
+            PatternErrorKind::InvalidRecursiveWildcards => {
+                "recursive wildcards must form a single path component"
+            }
+            PatternErrorKind::InvalidRange => "invalid range pattern",
+        };
+        write!(f, "{}", msg)
     }
 }
 
@@ -603,11 +627,6 @@ enum MatchResult {
     EntirePatternDoesntMatch,
 }
 
-const ERROR_WILDCARDS: &str = "wildcards are either regular `*` or recursive `**`";
-const ERROR_RECURSIVE_WILDCARDS: &str = "recursive wildcards must form a single path \
-                                         component";
-const ERROR_INVALID_RANGE: &str = "invalid range pattern";
-
 impl Pattern {
     /// This function compiles Unix shell style patterns.
     ///
@@ -641,7 +660,7 @@ impl Pattern {
                         Ordering::Greater => {
                             return Err(PatternError {
                                 pos: old + 2,
-                                msg: ERROR_WILDCARDS,
+                                kind: PatternErrorKind::InvalidWildcards,
                             })
                         }
                         Ordering::Equal => {
@@ -661,14 +680,14 @@ impl Pattern {
                                 } else {
                                     return Err(PatternError {
                                         pos: i,
-                                        msg: ERROR_RECURSIVE_WILDCARDS,
+                                        kind: PatternErrorKind::InvalidRecursiveWildcards,
                                     });
                                 }
                             // `**` begins with non-separator
                             } else {
                                 return Err(PatternError {
                                     pos: old - 1,
-                                    msg: ERROR_RECURSIVE_WILDCARDS,
+                                    kind: PatternErrorKind::InvalidRecursiveWildcards,
                                 });
                             };
 
@@ -718,7 +737,7 @@ impl Pattern {
                     // if we get here then this is not a valid range pattern
                     return Err(PatternError {
                         pos: i,
-                        msg: ERROR_INVALID_RANGE,
+                        kind: PatternErrorKind::InvalidRange,
                     });
                 }
                 c => {


### PR DESCRIPTION
Fixes #166
Initial proposal of the restructure of the PatterError, inspired by code proposed in Issue #166.
Added thiserror crate for the ease of work with the error messages, if this would be a problem please let me know.
Had to set version, due to rustc 1.63 used, because latest versions require rustc 1.68.

Also while coding wondered if maybe merging the newly created enum with the PatternError wouldn't be cleaner, but not sure. Showcase below
```
pub enum PatternError {
    /// Wildcard should be only `*` or `**`
    #[error("Patter error at position {pos}: wildcards are either regular `*` or recursive `**` ")]
    InvalidWildcards {pos: usize},
    ...
}
```