### PR TITLE
Cache filename for sorting in `fill_todo`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -965,9 +965,7 @@ fn fill_todo(
             match dirs {
                 Ok(mut children) => {
                     if options.require_literal_leading_dot {
-                        children.retain(|x| {
-                            !x.0.file_name().unwrap().to_str().unwrap().starts_with('.')
-                        });
+                        children.retain(|x| !x.1.to_str().unwrap().starts_with('.'));
                     }
                     children.sort_by(|p1, p2| p2.1.cmp(&p1.1));
                     todo.extend(children.into_iter().map(|x| Ok((x.0, idx))));


### PR DESCRIPTION
Alternative to https://github.com/rust-lang/glob/pull/144.

This reduces the duration to glob `**/*.rs` in a rustc checkout on my PC from ~1000ms to ~820ms:
```
Benchmark 1: ./local
  Time (mean ± σ):     822.0 ms ±  11.2 ms    [User: 272.5 ms, System: 549.2 ms]
  Range (min … max):   811.8 ms … 849.6 ms    10 runs
 
Benchmark 2: ./upstream
  Time (mean ± σ):      1.019 s ±  0.006 s    [User: 0.468 s, System: 0.551 s]
  Range (min … max):    1.005 s …  1.026 s    10 runs
 
Summary
  ./local ran
    1.24 ± 0.02 times faster than ./upstream
```